### PR TITLE
Add HOL Standards SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ Autonomous Agent for EDA."** *Zhuolun He (CUHK & Shanghai AI Lab) et al.* arXiv.
 * ![L2MAC Stars](https://img.shields.io/github/stars/samholt/L2MAC) [L2MAC](https://github.com/samholt/l2mac) - 🚀 The LLM Automatic Computer Framework: L2MAC
 * ![Yacana Stars](https://img.shields.io/github/stars/rememberSoftwares/yacana) [Yacana](https://github.com/rememberSoftwares/yacana) - 🔭🦙 Powering opensource LLMs with multi-agent chats and builing workflows.
 * ![Saplings Stars](https://img.shields.io/github/stars/shobrook/saplings) [Saplings](https://github.com/shobrook/saplings) – 🌳 Build smarter agents using tree search.
+* ![HOL Standards SDK Stars](https://img.shields.io/github/stars/hashgraph-online/standards-sdk) [HOL Standards SDK](https://github.com/hashgraph-online/standards-sdk) - Universal Agentic Registry SDK for AI agent discovery, blockchain-based identity (ERC-8004, UAIDs), and autonomous commerce via x402 protocol.
 
 ### Multi-Agent Simulation Projects
 


### PR DESCRIPTION
Adding Standards SDK to the Autonomous Task Solver Projects section.

Standards SDK is an open-source TypeScript framework for building AI agents on the Hedera network with agent discovery via the Registry Broker.

- GitHub: https://github.com/hashgraph-online/standards-sdk
- Docs: https://hol.org/docs/libraries/standards-sdk/overview/