### PR TITLE
Add Openwork to Autonomous Task Solver Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ Autonomous Agent for EDA."** *Zhuolun He (CUHK & Shanghai AI Lab) et al.* arXiv.
 * ![L2MAC Stars](https://img.shields.io/github/stars/samholt/L2MAC) [L2MAC](https://github.com/samholt/l2mac) - 🚀 The LLM Automatic Computer Framework: L2MAC
 * ![Yacana Stars](https://img.shields.io/github/stars/rememberSoftwares/yacana) [Yacana](https://github.com/rememberSoftwares/yacana) - 🔭🦙 Powering opensource LLMs with multi-agent chats and builing workflows.
 * ![Saplings Stars](https://img.shields.io/github/stars/shobrook/saplings) [Saplings](https://github.com/shobrook/saplings) – 🌳 Build smarter agents using tree search.
+* ![Openwork Stars](https://img.shields.io/github/stars/accomplish-ai/openwork) [Openwork](https://github.com/accomplish-ai/openwork) - MIT-licensed, open alternative to Anthropic's Cowork. Supports multiple LLM providers for launching computer-use agents to automate browser workflows.
 
 ### Multi-Agent Simulation Projects
 


### PR DESCRIPTION
## Summary
- Adds [Openwork](https://github.com/accomplish-ai/openwork) to the Autonomous Task Solver Projects section

## About Openwork
Openwork is an MIT-licensed, open alternative to Anthropic's Cowork, built using [Opencode](https://github.com/anomalyco/opencode) and [dev-browser](https://github.com/SawyerHood/dev-browser). It supports multiple LLM providers and lets users launch computer-use agents to automate real browser workflows—faster, safer, and fully open source.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)