### PR TITLE
Add Global Chat to Autonomous Task Solver Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ Autonomous Agent for EDA."** *Zhuolun He (CUHK & Shanghai AI Lab) et al.* arXiv.
 * ![L2MAC Stars](https://img.shields.io/github/stars/samholt/L2MAC) [L2MAC](https://github.com/samholt/l2mac) - 🚀 The LLM Automatic Computer Framework: L2MAC
 * ![Yacana Stars](https://img.shields.io/github/stars/rememberSoftwares/yacana) [Yacana](https://github.com/rememberSoftwares/yacana) - 🔭🦙 Powering opensource LLMs with multi-agent chats and builing workflows.
 * ![Saplings Stars](https://img.shields.io/github/stars/shobrook/saplings) [Saplings](https://github.com/shobrook/saplings) – 🌳 Build smarter agents using tree search.
+* ![Global Chat Stars](https://img.shields.io/github/stars/pumanitro/global-chat) [Global Chat](https://github.com/pumanitro/global-chat) - A protocol-agnostic AI agent discovery platform aggregating 100K+ agents across MCP, A2A, agents.txt, and 15+ registries.
 
 ### Multi-Agent Simulation Projects
 


### PR DESCRIPTION
Hi, thanks for maintaining this awesome list!

I'd like to add [Global Chat](https://github.com/pumanitro/global-chat) to the **Autonomous Task Solver Projects** section.

Global Chat is a protocol-agnostic AI agent discovery platform that aggregates 100K+ agents across MCP, A2A, agents.txt, ACDP, and 15+ other registries. It includes a searchable directory, a free agents.txt validator/linter, and an MCP server for programmatic access.

It fits under Autonomous Task Solver Projects as infrastructure for discovering and connecting to LLM-powered agents across fragmented registries.