### PR TITLE
Add Not Human Search to Other Related Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ Autonomous Agent for EDA."** *Zhuolun He (CUHK & Shanghai AI Lab) et al.* arXiv.
 
 ## Other Related Sources
 
+* [Not Human Search](https://nothumansearch.ai) - Search engine for AI agents. Indexes 1,400+ agent-first tools ranked by agentic readiness (MCP, OpenAPI, structured API signals). Available as MCP server.
 * [Personalized Generative AI](https://sites.google.com/view/pgai2023) @ CIKM'23
 * [LLM-Agents-Papers](https://github.com/AGI-Edgerunners/LLM-Agents-Papers) - A repo lists papers about LLM role playing, memory mechanism and LLM game playing.
 * [LLMAgentPapers](https://github.com/zjunlp/LLMAgentPapers) - Must-read papers on multiagents of LLMs.


### PR DESCRIPTION
## What is Not Human Search?

[Not Human Search](https://nothumansearch.ai) is a search engine purpose-built for AI agents. It indexes 1,400+ agent-first tools and ranks them by agentic readiness, evaluating MCP support, OpenAPI specs, and structured API signals.

**Why it fits this list:**
- Directly relevant to LLM-powered agents: it helps agents discover and evaluate tools they can use
- Provides an MCP server so agents can programmatically search for tools
- Ranks tools by "agentic readiness" - how well-suited they are for autonomous agent use
- Complements the research papers and projects listed here with a practical tool discovery resource

**Placement:** Added to "Other Related Sources" as a practical resource for LLM agent tool discovery.

**Website:** https://nothumansearch.ai