### PR TITLE
Add grugbot420 to Autonomous Task Solver Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ Autonomous Agent for EDA."** *Zhuolun He (CUHK & Shanghai AI Lab) et al.* arXiv.
 * ![L2MAC Stars](https://img.shields.io/github/stars/samholt/L2MAC) [L2MAC](https://github.com/samholt/l2mac) - 🚀 The LLM Automatic Computer Framework: L2MAC
 * ![Yacana Stars](https://img.shields.io/github/stars/rememberSoftwares/yacana) [Yacana](https://github.com/rememberSoftwares/yacana) - 🔭🦙 Powering opensource LLMs with multi-agent chats and builing workflows.
 * ![Saplings Stars](https://img.shields.io/github/stars/shobrook/saplings) [Saplings](https://github.com/shobrook/saplings) – 🌳 Build smarter agents using tree search.
+* ![grugbot420 Stars](https://img.shields.io/github/stars/grug-group420/grugbot420) [grugbot420](https://github.com/grug-group420/grugbot420) - A neuromorphic cognitive engine in Julia for multi-model AI orchestration. Deploys domain-expert AI specimens through architectural configuration rather than traditional training.
 
 ### Multi-Agent Simulation Projects
 


### PR DESCRIPTION
## grugbot420

[grugbot420](https://github.com/grug-group420/grugbot420) is a neuromorphic cognitive engine written in Julia for multi-model AI orchestration. It deploys domain-expert AI specimens through architectural configuration rather than traditional training.

- License: MIT
- Language: Julia
- Source: https://github.com/grug-group420/grugbot420