### PR TITLE
Add Dakera: self-hosted MCP memory infrastructure for LLM agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ Autonomous Agent for EDA."** *Zhuolun He (CUHK & Shanghai AI Lab) et al.* arXiv.
 * ![L2MAC Stars](https://img.shields.io/github/stars/samholt/L2MAC) [L2MAC](https://github.com/samholt/l2mac) - 🚀 The LLM Automatic Computer Framework: L2MAC
 * ![Yacana Stars](https://img.shields.io/github/stars/rememberSoftwares/yacana) [Yacana](https://github.com/rememberSoftwares/yacana) - 🔭🦙 Powering opensource LLMs with multi-agent chats and builing workflows.
 * ![Saplings Stars](https://img.shields.io/github/stars/shobrook/saplings) [Saplings](https://github.com/shobrook/saplings) – 🌳 Build smarter agents using tree search.
+* [Dakera](https://github.com/dakera-ai/dakera-mcp) - Self-hosted MCP memory infrastructure for LLM agents. Provides decay-weighted persistent memory, HNSW vector search, RocksDB-backed storage, and multi-agent namespacing via the Model Context Protocol.
 
 ### Multi-Agent Simulation Projects
 


### PR DESCRIPTION
## What

Adds [Dakera](https://github.com/dakera-ai/dakera-mcp) to the **Open-Source Projects → Autonomous Task Solver Projects** section.

## Why

Dakera is self-hosted memory infrastructure purpose-built for LLM-powered agents. It provides decay-weighted persistent memory, HNSW vector search, RocksDB-backed storage, and multi-agent namespacing via the Model Context Protocol. Agents built with frameworks like LangChain, Auto-GPT, or MetaGPT can use Dakera to maintain long-term memory across sessions without relying on cloud memory providers.

It complements the existing entries in this section (Auto-GPT, LangChain, MetaGPT, BabyAGI) as foundational memory infrastructure rather than an agent framework itself.

## Entry added

```
* [Dakera](https://github.com/dakera-ai/dakera-mcp) - Self-hosted MCP memory infrastructure for LLM agents. Provides decay-weighted persistent memory, HNSW vector search, RocksDB-backed storage, and multi-agent namespacing via the Model Context Protocol.
```