### PR TITLE
Add ClawBench (arXiv:2604.08523) to Autonomous Task Solver

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Our goal with this project is to build an exhaustive collection of awesome resou
 
 * [Sep 2023] **"You Only Look at Screens: Multimodal Chain-of-Action Agents."** *Zhuosheng Zhang (SJTU) et al.* arXiv. [[paper](https://arxiv.org/abs/2309.11436)] [[code](https://github.com/cooelf/Auto-UI)]
 * [Sep 2023] **"LASER: LLM Agent with State-Space Exploration for Web Navigation."** *Kaixin Ma (Tencent) et al.* arXiv. [[paper](https://arxiv.org/abs/2309.08172)] [[code](https://github.com/Mayer123/LASER)]
+* 🔥 [May 2026] **"ClawBench: Can AI Agents Complete Everyday Online Tasks?"** *Yuxuan Zhang (UBC) et al.* arXiv. [[paper](https://arxiv.org/abs/2604.08523)] [[code](https://github.com/reacher-z/ClawBench)] [[project page](https://claw-bench.com)] [[dataset](https://huggingface.co/datasets/NAIL-Group/ClawBench)]
 * 🔥 [Jul 2023] **"WebArena: A Realistic Web Environment for Building Autonomous Agents."** *Shuyan Zhou (CMU) et al.* arXiv. [[paper](https://arxiv.org/abs/2307.13854)] [[code](https://github.com/web-arena-x/webarena)] [[project page](https://webarena.dev)]
 * [Jul 2023] **"A Real-World WebAgent with Planning, Long Context Understanding, and Program Synthesis."** *Izzeddin Gur (DeepMind) et al.* arXiv. [[paper](https://arxiv.org/abs/2307.12856)]
 * 🔥📖 [Jun 2023] **"Mind2Web: Towards a Generalist Agent for the Web."** *Xiang Deng (OSU) et al.* NeurIPS 2023. [[paper](https://arxiv.org/abs/2306.06070)] [[code](https://github.com/OSU-NLP-Group/Mind2Web)] [[project page](https://osu-nlp-group.github.io/Mind2Web)]


### PR DESCRIPTION
Adds **ClawBench** to **Papers → Autonomous Task Solver** (right above WebArena / Mind2Web).

ClawBench evaluates LLM-powered browser agents on **live production websites** (not synthetic / sandboxed). Two-stage scoring: deterministic HTTP-request **interception** at per-task URL/method schema + **LLM judge** on the intercepted payload — catches "right endpoint, wrong payload" errors.

- arXiv: https://arxiv.org/abs/2604.08523 (May 2026)
- 283 tasks (V1 153 + V2 130) across 163 live platforms (15 life categories)
- Code: https://github.com/reacher-z/ClawBench · Live: https://claw-bench.com
- HF: [dataset](https://huggingface.co/datasets/NAIL-Group/ClawBench) · [traces V2](https://huggingface.co/datasets/TIGER-Lab/ClawBenchV2Trace)

Direct conversation partner with WebArena / Mind2Web / WebShop on methodology.

Affiliation: I'm one of the maintainers; happy to adjust copy or move to the Benchmark subsection if a better fit.
