### PR TITLE
Add AI Models Catalog to Other Related Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ Autonomous Agent for EDA."** *Zhuolun He (CUHK & Shanghai AI Lab) et al.* arXiv.
 * [Personalized Generative AI](https://sites.google.com/view/pgai2023) @ CIKM'23
 * [LLM-Agents-Papers](https://github.com/AGI-Edgerunners/LLM-Agents-Papers) - A repo lists papers about LLM role playing, memory mechanism and LLM game playing.
 * [LLMAgentPapers](https://github.com/zjunlp/LLMAgentPapers) - Must-read papers on multiagents of LLMs.
+* [AI Models Catalog](https://github.com/i-need-token/ai-models) - Structured database of 4,587+ AI models across 95 providers. Includes 1,080 agentic models (tool_call + reasoning) with pricing and capabilities. [Interactive catalog](https://i-need-token.github.io/ai-models/)
 * [awesome-llm-agents](https://github.com/kaushikb11/awesome-llm-agents) - A curated list of awesome LLM agents.
 
 ## Acknowledgement


### PR DESCRIPTION
## Description

Adds the AI Models Catalog to the "Other Related Sources" section — a structured, open-source database of 4,587+ AI models across 95 providers.

## Why This Is Useful for LLM Agent Researchers

- **1,080 agentic models**: Models with both tool_call and reasoning capabilities, ideal for LLM-powered agents
- **2,350 tool-calling models**: Comprehensive catalog of models that can use tools
- **Interactive catalog**: Filter by tool_call, reasoning, and other agent-relevant capabilities — https://i-need-token.github.io/ai-models/
- **Best AI Models for Agents page**: https://i-need-token.github.io/ai-models/best-ai-models-for-agents.html
- **Price calculator**: Calculate costs for agent workloads

## Links

- GitHub: https://github.com/i-need-token/ai-models
- Best AI Models for Agents: https://i-need-token.github.io/ai-models/best-ai-models-for-agents.html
- Interactive Catalog: https://i-need-token.github.io/ai-models/

## Checklist

- [x] The entry follows the existing format of the list
- [x] The entry is relevant to LLM agent researchers and practitioners
- [x] The description is concise and follows the style of other entries