### PR TITLE
Add TWZRD Agent Intel to Other Related Sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ Autonomous Agent for EDA."** *Zhuolun He (CUHK & Shanghai AI Lab) et al.* arXiv.
 
 ## Other Related Sources
 
+* [TWZRD Agent Intel](https://intel.twzrd.xyz) — Trust + receipt layer MCP server for AI agents on Solana. Pre-dispatch trust gating, on-chain scoring, and signed V5 trust receipts via x402 micropayment. Zero-install: `https://intel.twzrd.xyz/mcp` (Streamable HTTP).
 * [Personalized Generative AI](https://sites.google.com/view/pgai2023) @ CIKM'23
 * [LLM-Agents-Papers](https://github.com/AGI-Edgerunners/LLM-Agents-Papers) - A repo lists papers about LLM role playing, memory mechanism and LLM game playing.
 * [LLMAgentPapers](https://github.com/zjunlp/LLMAgentPapers) - Must-read papers on multiagents of LLMs.


### PR DESCRIPTION
## TWZRD Agent Intel

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the Other Related Sources section — a trust + receipt layer MCP server for AI agents on Solana.

**Zero-install MCP config:**
\`\`\`json
{
  "mcpServers": {
    "twzrd-agent-intel": {
      "url": "https://intel.twzrd.xyz/mcp"
    }
  }
}
\`\`\`

**4 free tools:** `resolve_agent`, `score_agent`, `preflight_check`, `verify_trust_receipt`
**1 paid tool:** `get_trust_receipt` (x402 micropayment, <1s Solana settlement)