### PR TITLE
feat: add EGC - persistent memory MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,8 @@ Autonomous Agent for EDA."** *Zhuolun He (CUHK & Shanghai AI Lab) et al.* arXiv.
 * ![OS-Copilot Stars](https://img.shields.io/github/stars/OS-Copilot/OS-Copilot) [L2MAC](https://github.com/OS-Copilot/OS-Copilot) - A self-improving conversational agent integrated into the operating system to automate daily tasks.
 * ![L2MAC Stars](https://img.shields.io/github/stars/samholt/L2MAC) [L2MAC](https://github.com/samholt/l2mac) - 🚀 The LLM Automatic Computer Framework: L2MAC
 * ![Yacana Stars](https://img.shields.io/github/stars/rememberSoftwares/yacana) [Yacana](https://github.com/rememberSoftwares/yacana) - 🔭🦙 Powering opensource LLMs with multi-agent chats and builing workflows.
-* ![Saplings Stars](https://img.shields.io/github/stars/shobrook/saplings) [Saplings](https://github.com/shobrook/saplings) – 🌳 Build smarter agents using tree search.
+* ![Saplings Stars](https://img.shields.io/github/stars/shobrook/saplings) [Saplings](https://github.com/shobrook/saplings) - Build smarter agents using tree search.
+* ![EGC Stars](https://img.shields.io/github/stars/Fmarzochi/EGC) [EGC](https://github.com/Fmarzochi/EGC) - Persistent cross-session memory MCP server for 13+ AI coding tools (Claude Code, Cursor, Gemini CLI, Codex, Windsurf, Amp, Kiro, and more). SQLite-backed state survives context resets. `npm install -g @egchq/egc`
 
 ### Multi-Agent Simulation Projects
 


### PR DESCRIPTION
## Description

Adds [EGC](https://github.com/Fmarzochi/EGC) to the Autonomous Task Solver Projects section.

EGC is a persistent cross-session memory MCP server for 13+ AI coding tools (Claude Code, Cursor, Gemini CLI, Codex, Windsurf, Amp, Kiro, VS Code Copilot, Trae, and more). It provides SQLite-backed persistent state that survives context resets, enabling LLM-powered agents to maintain memory across sessions.

- GitHub: https://github.com/Fmarzochi/EGC
- npm: `npm install -g @egchq/egc`
- License: MIT
- Stars: 20+