### PR TITLE
Add survey: Harness Engineering for Language Agents (CAR framework)

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ Autonomous Agent for EDA."** *Zhuolun He (CUHK & Shanghai AI Lab) et al.* arXiv.
 
 ### Survey & Tutorial
 
+* [Mar 2026] **"Harness Engineering for Language Agents: The Harness Layer as Control, Agency, and Runtime."** *Chaoyue He et al.* Preprints. [[paper](https://www.preprints.org/manuscript/202603.1756/v2)]
 * [Sep 2023] **"Natural Language based Context Modeling and Reasoning with LLMs: A Tutorial."** *Haoyi Xiong (Baidu) et al.* arXiv. [[paper](https://arxiv.org/abs/2309.15074)]
 * [Sep 2023] **"An In-depth Survey of Large Language Model-based Artificial Intelligence Agents."** *Pengyu Zhao (BJTU) et al.* arXiv. [[paper](https://arxiv.org/abs/2309.14365)]
 * 🔥 [Sep 2023] **"The Rise and Potential of Large Language Model Based Agents: A Survey."** *Zhiheng Xi (FDU) et al.* arXiv. [[paper](https://arxiv.org/abs/2309.07864)] [[GitHub](https://github.com/WooooDyy/LLM-Agent-Paper-List)]


### PR DESCRIPTION
Adds a recent survey/framework paper to **Papers → Survey & Tutorial**:

**"Harness Engineering for Language Agents: The Harness Layer as Control, Agency, and Runtime"** (Chaoyue He et al., Preprints 2026).

It decomposes the agent harness layer into **Control, Agency, and Runtime (CAR)**, situates harness engineering in the arc from software → prompt → context engineering, audits 63 harness-relevant works, and proposes **HarnessCard** as a reporting artifact.

Link: https://www.preprints.org/manuscript/202603.1756/v2 (DOI: [10.20944/preprints202603.1756](https://doi.org/10.20944/preprints202603.1756))

Entry follows the list format (`* [Mon Year] **"Title."** *Authors* Venue. [[paper](url)]`), placed at the top of Survey & Tutorial by date.