### PR TITLE
Add Declarative Agents (Nokia Bell Labs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ Autonomous Agent for EDA."** *Zhuolun He (CUHK & Shanghai AI Lab) et al.* arXiv.
 * ![L2MAC Stars](https://img.shields.io/github/stars/samholt/L2MAC) [L2MAC](https://github.com/samholt/l2mac) - 🚀 The LLM Automatic Computer Framework: L2MAC
 * ![Yacana Stars](https://img.shields.io/github/stars/rememberSoftwares/yacana) [Yacana](https://github.com/rememberSoftwares/yacana) - 🔭🦙 Powering opensource LLMs with multi-agent chats and builing workflows.
 * ![Saplings Stars](https://img.shields.io/github/stars/shobrook/saplings) [Saplings](https://github.com/shobrook/saplings) – 🌳 Build smarter agents using tree search.
+* ![Declarative Agents Stars](https://img.shields.io/github/stars/Nokia-Bell-Labs/declarative-agents) [Declarative Agents](https://github.com/Nokia-Bell-Labs/declarative-agents) - Tool-augmented LLM agents defined as YAML profiles (tools, states, transitions, signals, budgets) and interpreted by a single Go runtime, from Nokia Bell Labs.
 
 ### Multi-Agent Simulation Projects
 


### PR DESCRIPTION
Adds Declarative Agents to Open-Source Projects / Autonomous Task Solver Projects: tool-augmented LLM agents defined as YAML profiles (tools, states, transitions, signals, budgets) and interpreted by a single Go runtime. Open-sourced by Nokia Bell Labs under BSD 3-Clause; the repository includes an IEEE-format white paper, Design Patterns for Declarative Agents, documenting eleven patterns for reliable agents. Entry matches the existing shield + link + description format.