### PR TITLE
Add Persona to Open-Source Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ Autonomous Agent for EDA."** *Zhuolun He (CUHK & Shanghai AI Lab) et al.* arXiv.
 * ![L2MAC Stars](https://img.shields.io/github/stars/samholt/L2MAC) [L2MAC](https://github.com/samholt/l2mac) - 🚀 The LLM Automatic Computer Framework: L2MAC
 * ![Yacana Stars](https://img.shields.io/github/stars/rememberSoftwares/yacana) [Yacana](https://github.com/rememberSoftwares/yacana) - 🔭🦙 Powering opensource LLMs with multi-agent chats and builing workflows.
 * ![Saplings Stars](https://img.shields.io/github/stars/shobrook/saplings) [Saplings](https://github.com/shobrook/saplings) – 🌳 Build smarter agents using tree search.
+* ![Persona Stars](https://img.shields.io/github/stars/jayamitkatariya/personacli) [Persona](https://github.com/jayamitkatariya/personacli) - A local-first personal workspace: notes and tasks as plain Markdown, with an AI chat grounded in your own files.
 
 ### Multi-Agent Simulation Projects
 


### PR DESCRIPTION
Adds [Persona](https://github.com/jayamitkatariya/personacli) under **Open-Source Projects → Autonomous Task Solver Projects**.

Persona is a local-first personal workspace: Markdown notes and tasks stored on the user's machine, with an LLM chat grounded in those files. Works with Ollama or any OpenAI-compatible API. MIT.